### PR TITLE
Feat/ticket db schema entities

### DIFF
--- a/backend/src/main/java/com/smartcampus/model/TicketComment.java
+++ b/backend/src/main/java/com/smartcampus/model/TicketComment.java
@@ -1,0 +1,20 @@
+package com.smartcampus.model;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Table("ticket_comments")
+public record TicketComment(
+    @Id UUID id,
+    UUID ticketId,
+    UUID authorId,
+    String body,
+    boolean edited,
+    @CreatedDate Instant createdAt,
+    @LastModifiedDate Instant updatedAt
+) {}

--- a/backend/src/main/java/com/smartcampus/repository/TicketAttachmentRepository.java
+++ b/backend/src/main/java/com/smartcampus/repository/TicketAttachmentRepository.java
@@ -1,0 +1,15 @@
+package com.smartcampus.repository;
+
+import com.smartcampus.model.TicketAttachment;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface TicketAttachmentRepository extends ListCrudRepository<TicketAttachment, UUID> {
+    List<TicketAttachment> findByTicketId(UUID ticketId);
+
+    long countByTicketId(UUID ticketId);
+}

--- a/backend/src/main/java/com/smartcampus/repository/TicketCommentRepository.java
+++ b/backend/src/main/java/com/smartcampus/repository/TicketCommentRepository.java
@@ -1,0 +1,14 @@
+package com.smartcampus.repository;
+
+import com.smartcampus.model.TicketComment;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface TicketCommentRepository extends ListCrudRepository<TicketComment, UUID> {
+    List<TicketComment> findByTicketIdOrderByCreatedAtAsc(UUID ticketId);
+    long countByTicketId(UUID ticketId);
+}

--- a/backend/src/main/java/com/smartcampus/repository/TicketRepository.java
+++ b/backend/src/main/java/com/smartcampus/repository/TicketRepository.java
@@ -1,0 +1,24 @@
+package com.smartcampus.repository;
+
+import com.smartcampus.model.Ticket;
+import com.smartcampus.model.TicketStatus;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface TicketRepository extends ListCrudRepository<Ticket, UUID> {
+    List<Ticket> findByCreatedByOrderByCreatedAtDesc(UUID createdBy);
+
+    List<Ticket> findByAssignedToOrderByCreatedAtDesc(UUID assignedTo);
+
+    List<Ticket> findAllByOrderByCreatedAtDesc();
+
+    List<Ticket> findByStatusOrderByCreatedAtDesc(TicketStatus status);
+
+    List<Ticket> findByStatusIn(List<TicketStatus> statuses);
+
+    long countByStatus(TicketStatus status);
+}


### PR DESCRIPTION
This pull request introduces new data models and repository interfaces for managing tickets, ticket comments, and ticket attachments in the backend. The changes establish the foundation for CRUD operations and queries related to tickets and their associated entities.

**New data models:**

* Added the `TicketComment` record to represent ticket comments, including fields for author, body, timestamps, and edit status. (`TicketComment.java`)

**Repository interfaces for CRUD and queries:**

* Added `TicketRepository` with methods to find tickets by creator, assignee, status, and to count tickets by status. (`TicketRepository.java`)
* Added `TicketCommentRepository` with methods to retrieve and count comments for a ticket, ordered by creation time. (`TicketCommentRepository.java`)
* Added `TicketAttachmentRepository` with methods to retrieve and count attachments for a ticket. (`TicketAttachmentRepository.java`)