### PR TITLE
Feat/ticket comments

### DIFF
--- a/backend/src/main/java/com/smartcampus/controller/TicketCommentController.java
+++ b/backend/src/main/java/com/smartcampus/controller/TicketCommentController.java
@@ -1,0 +1,61 @@
+package com.smartcampus.controller;
+
+import com.smartcampus.dto.CommentResponse;
+import com.smartcampus.dto.CreateCommentRequest;
+import com.smartcampus.service.TicketCommentService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/tickets/{ticketId}/comments")
+public class TicketCommentController {
+
+    private final TicketCommentService commentService;
+
+    public TicketCommentController(TicketCommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    /** POST: /api/tickets/{ticketId}/comments */
+    @PostMapping
+    public ResponseEntity<CommentResponse> addComment(
+            @PathVariable UUID ticketId,
+            @Valid @RequestBody CreateCommentRequest request,
+            @AuthenticationPrincipal OAuth2User principal) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(commentService.addComment(ticketId, request, principal));
+    }
+
+    /** GET: /api/tickets/{ticketId}/comments */
+    @GetMapping
+    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable UUID ticketId) {
+        return ResponseEntity.ok(commentService.getComments(ticketId));
+    }
+
+    /** PUT: /api/tickets/{ticketId}/comments/{commentId} */
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> editComment(
+            @PathVariable UUID ticketId,
+            @PathVariable UUID commentId,
+            @Valid @RequestBody CreateCommentRequest request,
+            @AuthenticationPrincipal OAuth2User principal) {
+        return ResponseEntity.ok(commentService.editComment(ticketId, commentId, request, principal));
+    }
+
+    /** DELETE: /api/tickets/{ticketId}/comments/{commentId} */
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable UUID ticketId,
+            @PathVariable UUID commentId,
+            @AuthenticationPrincipal OAuth2User principal) {
+        commentService.deleteComment(ticketId, commentId, principal);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/smartcampus/dto/CommentResponse.java
+++ b/backend/src/main/java/com/smartcampus/dto/CommentResponse.java
@@ -1,0 +1,15 @@
+package com.smartcampus.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record CommentResponse(
+        UUID id,
+        UUID ticketId,
+        UUID authorId,
+        String authorName,
+        String body,
+        boolean edited,
+        Instant createdAt,
+        Instant updatedAt) {
+}

--- a/backend/src/main/java/com/smartcampus/dto/CreateCommentRequest.java
+++ b/backend/src/main/java/com/smartcampus/dto/CreateCommentRequest.java
@@ -1,0 +1,8 @@
+package com.smartcampus.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateCommentRequest(
+        @NotBlank(message = "Comment body is required") @Size(min = 1, max = 1000, message = "Comment must be between 1 and 1000 characters") String body) {
+}

--- a/backend/src/main/java/com/smartcampus/service/TicketCommentService.java
+++ b/backend/src/main/java/com/smartcampus/service/TicketCommentService.java
@@ -6,6 +6,7 @@ import com.smartcampus.exception.ResourceNotFoundException;
 import com.smartcampus.exception.UnauthorizedActionException;
 import com.smartcampus.model.TicketComment;
 import com.smartcampus.model.User;
+import com.smartcampus.model.UserRole;
 import com.smartcampus.repository.TicketCommentRepository;
 import com.smartcampus.repository.TicketRepository;
 import com.smartcampus.repository.UserRepository;
@@ -65,6 +66,20 @@ public class TicketCommentService {
         return toResponse(commentRepository.save(updated));
     }
 
+    public void deleteComment(UUID ticketId, UUID commentId, OAuth2User principal) {
+        User currentUser = resolveUser(principal);
+        TicketComment comment = findComment(ticketId, commentId);
+
+        boolean isOwner = comment.authorId().equals(currentUser.id());
+        boolean isAdmin = currentUser.role() == UserRole.SUPER_ADMIN
+                || currentUser.role() == UserRole.DOMAIN_ADMIN;
+
+        if (!isOwner && !isAdmin) {
+            throw new UnauthorizedActionException("You can only delete your own comments");
+        }
+        commentRepository.deleteById(commentId);
+    }
+
     private TicketComment findComment(UUID ticketId, UUID commentId) {
         TicketComment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new ResourceNotFoundException("Comment not found: " + commentId));
@@ -86,5 +101,4 @@ public class TicketCommentService {
         return new CommentResponse(c.id(), c.ticketId(), c.authorId(), authorName,
                 c.body(), c.edited(), c.createdAt(), c.updatedAt());
     }
-
 }

--- a/backend/src/main/java/com/smartcampus/service/TicketCommentService.java
+++ b/backend/src/main/java/com/smartcampus/service/TicketCommentService.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -38,6 +39,14 @@ public class TicketCommentService {
         TicketComment comment = new TicketComment(
                 null, ticketId, currentUser.id(), request.body(), false, null, null);
         return toResponse(commentRepository.save(comment));
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getComments(UUID ticketId) {
+        ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new ResourceNotFoundException("Ticket not found: " + ticketId));
+        return commentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId)
+                .stream().map(this::toResponse).toList();
     }
 
     private User resolveUser(OAuth2User principal) {

--- a/backend/src/main/java/com/smartcampus/service/TicketCommentService.java
+++ b/backend/src/main/java/com/smartcampus/service/TicketCommentService.java
@@ -1,0 +1,56 @@
+package com.smartcampus.service;
+
+import com.smartcampus.dto.CommentResponse;
+import com.smartcampus.dto.CreateCommentRequest;
+import com.smartcampus.exception.ResourceNotFoundException;
+import com.smartcampus.model.TicketComment;
+import com.smartcampus.model.User;
+import com.smartcampus.repository.TicketCommentRepository;
+import com.smartcampus.repository.TicketRepository;
+import com.smartcampus.repository.UserRepository;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Transactional
+public class TicketCommentService {
+
+    private final TicketCommentRepository commentRepository;
+    private final TicketRepository ticketRepository;
+    private final UserRepository userRepository;
+
+    public TicketCommentService(TicketCommentRepository commentRepository,
+            TicketRepository ticketRepository,
+            UserRepository userRepository) {
+        this.commentRepository = commentRepository;
+        this.ticketRepository = ticketRepository;
+        this.userRepository = userRepository;
+    }
+
+    public CommentResponse addComment(UUID ticketId, CreateCommentRequest request, OAuth2User principal) {
+        User currentUser = resolveUser(principal);
+        ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new ResourceNotFoundException("Ticket not found: " + ticketId));
+
+        TicketComment comment = new TicketComment(
+                null, ticketId, currentUser.id(), request.body(), false, null, null);
+        return toResponse(commentRepository.save(comment));
+    }
+
+    private User resolveUser(OAuth2User principal) {
+        String email = principal.getAttribute("email");
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Authenticated user not found"));
+    }
+
+    private CommentResponse toResponse(TicketComment c) {
+        String authorName = userRepository.findById(c.authorId())
+                .map(User::fullName).orElse("Unknown");
+        return new CommentResponse(c.id(), c.ticketId(), c.authorId(), authorName,
+                c.body(), c.edited(), c.createdAt(), c.updatedAt());
+    }
+
+}

--- a/backend/src/main/java/com/smartcampus/service/TicketCommentService.java
+++ b/backend/src/main/java/com/smartcampus/service/TicketCommentService.java
@@ -3,6 +3,7 @@ package com.smartcampus.service;
 import com.smartcampus.dto.CommentResponse;
 import com.smartcampus.dto.CreateCommentRequest;
 import com.smartcampus.exception.ResourceNotFoundException;
+import com.smartcampus.exception.UnauthorizedActionException;
 import com.smartcampus.model.TicketComment;
 import com.smartcampus.model.User;
 import com.smartcampus.repository.TicketCommentRepository;
@@ -47,6 +48,30 @@ public class TicketCommentService {
                 .orElseThrow(() -> new ResourceNotFoundException("Ticket not found: " + ticketId));
         return commentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId)
                 .stream().map(this::toResponse).toList();
+    }
+
+    public CommentResponse editComment(UUID ticketId, UUID commentId,
+            CreateCommentRequest request, OAuth2User principal) {
+        User currentUser = resolveUser(principal);
+        TicketComment existing = findComment(ticketId, commentId);
+
+        if (!existing.authorId().equals(currentUser.id())) {
+            throw new UnauthorizedActionException("You can only edit your own comments");
+        }
+
+        TicketComment updated = new TicketComment(
+                existing.id(), existing.ticketId(), existing.authorId(),
+                request.body(), true, existing.createdAt(), null);
+        return toResponse(commentRepository.save(updated));
+    }
+
+    private TicketComment findComment(UUID ticketId, UUID commentId) {
+        TicketComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Comment not found: " + commentId));
+        if (!comment.ticketId().equals(ticketId)) {
+            throw new ResourceNotFoundException("Comment does not belong to this ticket");
+        }
+        return comment;
     }
 
     private User resolveUser(OAuth2User principal) {

--- a/backend/src/test/java/com/smartcampus/TicketCommentTests.java
+++ b/backend/src/test/java/com/smartcampus/TicketCommentTests.java
@@ -1,0 +1,102 @@
+package com.smartcampus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartcampus.dto.CreateCommentRequest;
+import com.smartcampus.model.*;
+import com.smartcampus.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class TicketCommentTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private TicketRepository ticketRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private User activeUser;
+    private Ticket ticket;
+
+    @BeforeEach
+    void setup() {
+        activeUser = userRepository.save(new User(
+                null, "google-comment-test", "comment-test@example.com", "Comment Tester",
+                null, null, null, null,
+                UserRole.STUDENT, UserStatus.ACTIVE, null, null, null, null));
+        ticket = ticketRepository.save(new Ticket(
+                null, activeUser.id(), null, null, "Lab 302",
+                TicketCategory.NETWORK, "Wi-Fi keeps dropping in lab 302",
+                TicketPriority.MEDIUM, "comment-test@example.com",
+                TicketStatus.OPEN, null, null, null, null, 0, null, null));
+    }
+
+    @Test
+    void addComment_shouldReturn201() throws Exception {
+        CreateCommentRequest req = new CreateCommentRequest("This is a test comment");
+
+        mockMvc.perform(post("/api/tickets/{ticketId}/comments", ticket.id())
+                .with(csrf())
+                .with(oauth2Login()
+                        .authorities(new SimpleGrantedAuthority("STATUS_ACTIVE"))
+                        .attributes(a -> {
+                            a.put("sub", "google-comment-test");
+                            a.put("email", "comment-test@example.com");
+                        }))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.body").value("This is a test comment"))
+                .andExpect(jsonPath("$.edited").value(false));
+    }
+
+    @Test
+    void getComments_shouldReturn200() throws Exception {
+        mockMvc.perform(get("/api/tickets/{ticketId}/comments", ticket.id())
+                .with(oauth2Login()
+                        .authorities(new SimpleGrantedAuthority("STATUS_ACTIVE"))
+                        .attributes(a -> {
+                            a.put("sub", "google-comment-test");
+                            a.put("email", "comment-test@example.com");
+                        })))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void addComment_blankBody_shouldReturn400() throws Exception {
+        CreateCommentRequest req = new CreateCommentRequest("");
+
+        mockMvc.perform(post("/api/tickets/{ticketId}/comments", ticket.id())
+                .with(csrf())
+                .with(oauth2Login()
+                        .authorities(new SimpleGrantedAuthority("STATUS_ACTIVE"))
+                        .attributes(a -> {
+                            a.put("sub", "google-comment-test");
+                            a.put("email", "comment-test@example.com");
+                        }))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
This pull request introduces a complete implementation of ticket comment functionality in the backend, including API endpoints, service logic, DTOs, and integration tests. The changes enable users to add, retrieve, edit, and delete comments on tickets, with appropriate validation and authorization.

**Ticket Comment Feature Implementation:**

*API Layer:*
- Added `TicketCommentController` with REST endpoints for adding, retrieving, editing, and deleting comments on tickets, using path variables for `ticketId` and `commentId`, and enforcing authentication and validation.

*Service Layer:*
- Implemented `TicketCommentService` to handle business logic for comment operations, including user resolution, authorization checks (ensuring only comment authors or admins can delete), and mapping between entities and DTOs.

*Data Transfer Objects (DTOs):*
- Introduced `CommentResponse` to structure comment data returned by the API, and `CreateCommentRequest` with validation for comment creation and editing. [[1]](diffhunk://#diff-5a138b96ec8863be451781fd5336ab5fb4090be1e46f3d76dfa85ca3f419c027R1-R15) [[2]](diffhunk://#diff-73e5e7bcf607a30b959b85f93bb964d76cf86cdb52d6034944e0cfd7312e2d1aR1-R8)

*Testing:*
- Added integration tests in `TicketCommentTests` to verify comment creation, retrieval, and validation (including blank body rejection), using Spring Boot's test framework and mock authentication.