### PR TITLE
fix(docker): make Dockerfile cross-platform for Mac and Windows

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 COPY .mvn .mvn
 COPY mvnw pom.xml ./
-RUN chmod +x mvnw && ./mvnw dependency:resolve -B
+RUN sed -i 's/\r$//' mvnw && chmod +x mvnw && ./mvnw dependency:resolve -B
 COPY src ./src
 RUN ./mvnw package -DskipTests -B
 


### PR DESCRIPTION
- Add sed to strip CRLF line endings from mvnw before chmod
- Ensures mvnw executes correctly on both Unix and Windows hosts
- Add trailing newline to ENTRYPOINT line