### PR TITLE
Add AttachmentUploader and integrate into page

### DIFF
--- a/frontend/src/components/tickets/AttachmentUploader.tsx
+++ b/frontend/src/components/tickets/AttachmentUploader.tsx
@@ -1,0 +1,99 @@
+import React, { useRef } from 'react';
+import { UploadIcon, XIcon, ImageIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+    pendingFiles: File[];
+    onFilesChange: (files: File[]) => void;
+    maxFiles: number;
+    // For existing attachments on the detail page
+    existingUrls?: { id: string; filename: string; publicUrl: string }[];
+    onDeleteExisting?: (id: string) => void;
+}
+
+export const AttachmentUploader: React.FC<Props> = ({
+    pendingFiles,
+    onFilesChange,
+    maxFiles,
+    existingUrls = [],
+    onDeleteExisting,
+}) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const totalCount = existingUrls.length + pendingFiles.length;
+
+    const handleFiles = (files: FileList | null) => {
+        if (!files) return;
+        const allowed = maxFiles - totalCount;
+        if (allowed <= 0) return;
+        const selected = Array.from(files).slice(0, allowed);
+        const imageOnly = selected.filter((f) =>
+            ['image/jpeg', 'image/png', 'image/webp', 'image/gif'].includes(f.type)
+        );
+        onFilesChange([...pendingFiles, ...imageOnly]);
+    };
+
+    const removePending = (index: number) => {
+        const updated = [...pendingFiles];
+        updated.splice(index, 1);
+        onFilesChange(updated);
+    };
+
+    return (
+        <div className="space-y-3">
+            {/* Existing attachments */}
+            {existingUrls.map((a) => (
+                <div key={a.id} className="flex items-center gap-3 bg-muted/30 border border-border p-3">
+                    <a href={a.publicUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 flex-1 min-w-0">
+                        <ImageIcon className="size-4 text-muted-foreground shrink-0" />
+                        <span className="text-xs text-primary truncate font-medium">{a.filename}</span>
+                    </a>
+                    {onDeleteExisting && (
+                        <button
+                            type="button"
+                            onClick={() => onDeleteExisting(a.id)}
+                            className="text-destructive hover:text-destructive/70 transition-colors"
+                        >
+                            <XIcon className="size-4" />
+                        </button>
+                    )}
+                </div>
+            ))}
+
+            {/* Pending files */}
+            {pendingFiles.map((f, i) => (
+                <div key={i} className="flex items-center gap-3 bg-secondary/5 border border-secondary/30 p-3">
+                    <ImageIcon className="size-4 text-secondary shrink-0" />
+                    <span className="text-xs text-primary flex-1 truncate font-medium">{f.name}</span>
+                    <span className="text-[10px] text-muted-foreground">{(f.size / 1024).toFixed(0)} KB</span>
+                    <button type="button" onClick={() => removePending(i)} className="text-destructive hover:text-destructive/70">
+                        <XIcon className="size-4" />
+                    </button>
+                </div>
+            ))}
+
+            {/* Upload trigger */}
+            {totalCount < maxFiles && (
+                <>
+                    <input
+                        ref={inputRef}
+                        type="file"
+                        accept="image/jpeg,image/png,image/webp,image/gif"
+                        multiple
+                        className="hidden"
+                        onChange={(e) => handleFiles(e.target.files)}
+                    />
+                    <button
+                        type="button"
+                        onClick={() => inputRef.current?.click()}
+                        className="w-full border-2 border-dashed border-border hover:border-secondary transition-colors p-6 flex flex-col items-center gap-2 group"
+                    >
+                        <UploadIcon className="size-6 text-muted-foreground group-hover:text-secondary transition-colors" />
+                        <p className="text-xs text-muted-foreground group-hover:text-primary transition-colors">
+                            Click to upload ({totalCount}/{maxFiles} images) — JPEG, PNG, WEBP, GIF
+                        </p>
+                    </button>
+                </>
+            )}
+        </div>
+    );
+};

--- a/frontend/src/pages/tickets/CreateTicketPage.tsx
+++ b/frontend/src/pages/tickets/CreateTicketPage.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { DuplicateSidebar } from '@/components/tickets/DuplicateSidebar';
+import { AttachmentUploader } from '@/components/tickets/AttachmentUploader';
 import { toast } from 'sonner';
 import type { TicketCategory, TicketPriority, DuplicateSuggestion } from '@/types/ticket';
 
@@ -226,6 +227,18 @@ const CreateTicketPage: React.FC = () => {
                             onChange={handleChange('preferredContact')}
                             required
                             className="h-12 bg-transparent border-0 border-b-2 border-border rounded-none focus-visible:ring-0 focus-visible:border-primary px-0 text-base"
+                        />
+                    </div>
+
+                    {/* Attachment Uploader */}
+                    <div className="space-y-3">
+                        <Label className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">
+                            Evidence Images <span className="normal-case font-normal text-muted-foreground/60">(up to 3)</span>
+                        </Label>
+                        <AttachmentUploader
+                            pendingFiles={pendingFiles}
+                            onFilesChange={setPendingFiles}
+                            maxFiles={3}
                         />
                     </div>
 


### PR DESCRIPTION
This pull request introduces an image attachment uploader to the ticket creation page, allowing users to add up to three evidence images (JPEG, PNG, WEBP, or GIF) when creating a ticket. The main changes include implementing the `AttachmentUploader` component and integrating it into the ticket creation form.

**Attachment uploader implementation:**

* Added a new `AttachmentUploader` React component (`frontend/src/components/tickets/AttachmentUploader.tsx`) that manages pending image file uploads, enforces file type and count restrictions, displays previews for selected files, and supports removal of files before submission.

**Integration into ticket creation page:**

* Imported the `AttachmentUploader` component into the ticket creation page (`frontend/src/pages/tickets/CreateTicketPage.tsx`).
* Added the `AttachmentUploader` to the ticket creation form UI, allowing users to select up to three evidence images and view their selected files.Introduce a new AttachmentUploader component to manage pending and existing image attachments (JPEG, PNG, WEBP, GIF). The component enforces a max file count, filters to image types, shows file size and names, and exposes callbacks for adding/removing files and deleting existing attachments. Wire the uploader into CreateTicketPage with a labeled section for evidence images (max 3).