### PR TITLE
Fix/ticket role permissions

### DIFF
--- a/backend/src/main/java/com/smartcampus/service/TicketService.java
+++ b/backend/src/main/java/com/smartcampus/service/TicketService.java
@@ -171,7 +171,7 @@ public class TicketService {
                 User currentUser = resolveUser(principal);
                 Ticket ticket = findTicket(ticketId);
 
-                validateStatusTransition(ticket.status(), request.status(), currentUser);
+                validateStatusTransition(ticket.status(), request.status(), currentUser, ticketId);
 
                 String rejectionReason = ticket.rejectionReason();
                 if (request.status() == TicketStatus.REJECTED) {
@@ -277,7 +277,7 @@ public class TicketService {
 
         // HELPERS
 
-        private void validateStatusTransition(TicketStatus current, TicketStatus next, User actor) {
+        private void validateStatusTransition(TicketStatus current, TicketStatus next, User actor, UUID ticketId) {
                 // Technicians can move OPEN→IN_PROGRESS→RESOLVED
                 // Admins can do all transitions including REJECTED and CLOSED
                 boolean isAdmin = isAdmin(actor);
@@ -303,8 +303,18 @@ public class TicketService {
                                         throw new UnauthorizedActionException("Only admin can close tickets");
                         }
                         case REJECTED -> {
-                                if (!isAdmin)
+                                if (!isAdmin(actor))
                                         throw new UnauthorizedActionException("Only admin can reject tickets");
+                                // Domain admins may only reject tickets belonging to their own domain
+                                if (actor.role() == UserRole.DOMAIN_ADMIN) {
+                                        Ticket t = ticketRepository.findById(ticketId)
+                                                        .orElseThrow(() -> new ResourceNotFoundException(
+                                                                        "Ticket not found"));
+                                        if (t.domainId() == null || !t.domainId().equals(actor.domainId())) {
+                                                throw new UnauthorizedActionException(
+                                                                "Domain admins can only reject tickets in their own domain");
+                                        }
+                                }
                         }
                         default -> throw new IllegalStateException("Invalid target status: " + next);
                 }

--- a/backend/src/main/java/com/smartcampus/service/TicketService.java
+++ b/backend/src/main/java/com/smartcampus/service/TicketService.java
@@ -52,6 +52,10 @@ public class TicketService {
         public TicketResponse createTicket(CreateTicketRequest request, OAuth2User principal) {
                 User currentUser = resolveUser(principal);
 
+                if (currentUser.role() != UserRole.STUDENT && currentUser.role() != UserRole.DOMAIN_ADMIN) {
+                        throw new UnauthorizedActionException("Only students and domain admins may create tickets");
+                }
+
                 Ticket ticket = new Ticket(
                                 null,
                                 currentUser.id(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,7 +80,7 @@ function App() {
 
           {/* ── Tickets ── */}
           <Route path="/tickets" element={<ProtectedPage><TicketListPage /></ProtectedPage>} />
-          <Route path="/tickets/new" element={<ProtectedPage><CreateTicketPage /></ProtectedPage>} />
+          <Route path="/tickets/new" element={<ProtectedPage allowedRoles={['STUDENT', 'DOMAIN_ADMIN']}><CreateTicketPage /></ProtectedPage>} />
           <Route path="/tickets/:id" element={<ProtectedPage><TicketDetailPage /></ProtectedPage>} />
 
           {/* ── Admin (sidebar layout) ── */}

--- a/frontend/src/pages/tickets/TicketDetailPage.tsx
+++ b/frontend/src/pages/tickets/TicketDetailPage.tsx
@@ -46,6 +46,11 @@ const TicketDetailPage: React.FC = () => {
     const isTechnician = user?.role === 'TECHNICIAN';
     const isOwner = ticket?.createdBy === user?.id;
     const isAssignedTech = isTechnician && ticket?.assignedTo === user?.id;
+    const isSuperAdmin = user?.role === 'SUPER_ADMIN';
+    const isDomainAdmin = user?.role === 'DOMAIN_ADMIN';
+    // Domain admins can only reject if the ticket belongs to their domain
+    const canReject = isSuperAdmin || (isDomainAdmin && (ticket.domainId === user?.domainId || !ticket.domainId));
+
 
     // Workflow state
     const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
@@ -147,8 +152,9 @@ const TicketDetailPage: React.FC = () => {
     // Compute available next statuses
     let nextStatuses: TicketStatus[] = [];
     if (isAdmin) {
-        nextStatuses = [...(STAFF_TRANSITIONS[ticket.status] ?? []), ...ADMIN_EXTRA]
-            .filter((s) => s !== ticket.status);
+        const baseTransitions = STAFF_TRANSITIONS[ticket.status] ?? [];
+        const adminExtras = canReject ? [...ADMIN_EXTRA] : [];
+        nextStatuses = [...baseTransitions, ...adminExtras].filter((s) => s !== ticket.status);
     } else if (isAssignedTech) {
         nextStatuses = STAFF_TRANSITIONS[ticket.status] ?? [];
     }

--- a/frontend/src/pages/tickets/TicketDetailPage.tsx
+++ b/frontend/src/pages/tickets/TicketDetailPage.tsx
@@ -17,14 +17,11 @@ import { format } from 'date-fns';
 import { toast } from 'sonner';
 import type { TicketStatus } from '@/types/ticket';
 
-const ALLOWED_TRANSITIONS: Record<TicketStatus, TicketStatus[]> = {
+const STAFF_TRANSITIONS: Partial<Record<TicketStatus, TicketStatus[]>> = {
     OPEN: ['IN_PROGRESS'],
     IN_PROGRESS: ['RESOLVED'],
     RESOLVED: ['CLOSED'],
-    CLOSED: [],
-    REJECTED: [],
 };
-
 const ADMIN_EXTRA: TicketStatus[] = ['REJECTED'];
 
 const STATUS_LABELS: Record<TicketStatus, string> = {
@@ -148,10 +145,13 @@ const TicketDetailPage: React.FC = () => {
     }
 
     // Compute available next statuses
-    let nextStatuses: TicketStatus[] = ALLOWED_TRANSITIONS[ticket.status] ?? [];
-    if (isAdmin) nextStatuses = [...nextStatuses, ...ADMIN_EXTRA].filter((s) => s !== ticket.status);
-    // Technicians can only advance if assigned to the ticket
-    if (isTechnician && !isAssignedTech) nextStatuses = [];
+    let nextStatuses: TicketStatus[] = [];
+    if (isAdmin) {
+        nextStatuses = [...(STAFF_TRANSITIONS[ticket.status] ?? []), ...ADMIN_EXTRA]
+            .filter((s) => s !== ticket.status);
+    } else if (isAssignedTech) {
+        nextStatuses = STAFF_TRANSITIONS[ticket.status] ?? [];
+    }
 
     const canAddResolution = (isAssignedTech || isAdmin) && ticket.status !== 'CLOSED' && ticket.status !== 'REJECTED';
     const canAssign = isAdmin && ticket.status !== 'CLOSED' && ticket.status !== 'REJECTED';

--- a/frontend/src/pages/tickets/TicketListPage.tsx
+++ b/frontend/src/pages/tickets/TicketListPage.tsx
@@ -100,6 +100,7 @@ function TicketTable({ tickets, isLoading }: { tickets: TicketResponse[]; isLoad
 
 const TicketListPage: React.FC = () => {
     const { user } = useAuth();
+    const canCreateTicket = user?.role === 'STUDENT' || user?.role === 'DOMAIN_ADMIN';
     const isAdmin = user?.role === 'SUPER_ADMIN' || user?.role === 'DOMAIN_ADMIN';
     const isTechnician = user?.role === 'TECHNICIAN';
 
@@ -128,11 +129,13 @@ const TicketListPage: React.FC = () => {
                                 Report and track facility incidents and technical issues across campus.
                             </p>
                         </div>
-                        <Link to="/tickets/new">
-                            <Button className="h-10 bg-secondary text-white hover:bg-secondary/80 font-bold tracking-widest uppercase text-xs flex items-center gap-2">
-                                <PlusIcon className="size-4" /> New Ticket
-                            </Button>
-                        </Link>
+                        {canCreateTicket && (
+                            <Link to="/tickets/new">
+                                <Button className="h-10 bg-secondary text-white hover:bg-secondary/80 font-bold tracking-widest uppercase text-xs flex items-center gap-2">
+                                    <PlusIcon className="size-4" /> New Ticket
+                                </Button>
+                            </Link>
+                        )}
                     </div>
                 </div>
             </header>
@@ -140,7 +143,7 @@ const TicketListPage: React.FC = () => {
             <main className="max-w-7xl mx-auto px-8">
                 <Tabs value={tab} onValueChange={setTab}>
                     <TabsList className="mb-6">
-                        {(isAdmin || !isTechnician) && (
+                        {user?.role !== 'SUPER_ADMIN' && user?.role !== 'DOMAIN_ADMIN' && !isTechnician && (
                             <TabsTrigger value="mine">
                                 <TicketIcon className="size-4" /> My Tickets
                             </TabsTrigger>


### PR DESCRIPTION
This pull request implements stricter role-based access control for ticket creation and status transitions in both the backend and frontend. The main changes ensure that only students and domain admins can create tickets, and that only admins (with additional domain checks for domain admins) can reject tickets. The frontend now aligns with these backend rules, both in what UI is shown and in allowed actions.

**Backend: Role-based access and status transition enforcement**
- Only users with the `STUDENT` or `DOMAIN_ADMIN` roles can create tickets; all others receive an unauthorized error.
- The `validateStatusTransition` method now requires the ticket ID, and enforces that only admins can reject tickets. For domain admins, it further checks that they can only reject tickets within their own domain. [[1]](diffhunk://#diff-f103092a84b67c363904add135cc0bade310945d01201b15b1c3be132427ff65L174-R178) [[2]](diffhunk://#diff-f103092a84b67c363904add135cc0bade310945d01201b15b1c3be132427ff65L280-R284) [[3]](diffhunk://#diff-f103092a84b67c363904add135cc0bade310945d01201b15b1c3be132427ff65L306-R321)

**Frontend: UI and logic updates for ticket creation and transitions**
- The `/tickets/new` route is now only accessible to `STUDENT` and `DOMAIN_ADMIN` users, matching backend restrictions.
- The "New Ticket" button is only shown to users allowed to create tickets. [[1]](diffhunk://#diff-41944a7efde1db95554a5c14da24d737ce393003e5bbbc7262e9b6707a389ebbR103) [[2]](diffhunk://#diff-41944a7efde1db95554a5c14da24d737ce393003e5bbbc7262e9b6707a389ebbR132-R146)
- Ticket status transition logic is updated: only admins (with proper domain permissions) or assigned technicians can move tickets to the next status, and only eligible admins can reject tickets. [[1]](diffhunk://#diff-86a180c43fd97df616bd74bcba9522f72767e92c48a80f5cf26e2bccd35b067eL20-L27) [[2]](diffhunk://#diff-86a180c43fd97df616bd74bcba9522f72767e92c48a80f5cf26e2bccd35b067eR49-R53) [[3]](diffhunk://#diff-86a180c43fd97df616bd74bcba9522f72767e92c48a80f5cf26e2bccd35b067eL151-R160)